### PR TITLE
展开按钮点击击穿问题

### DIFF
--- a/mip-showmore/mip-showmore.js
+++ b/mip-showmore/mip-showmore.js
@@ -206,6 +206,7 @@ define(function (require) {
         var classList = this.ele.classList;
         var clickBtn = event ? event.target : null;
         var opt = {};
+        event.preventDefault();
         opt.aniTime = this.animateTime;
         if (this.showType === this.heightType[2]) {
             // 高度限制


### PR DESCRIPTION
点击mip-showmore组件的展开按钮时，如果按钮的下方是a标签的话，会导致a标签的click响应

温馨提示：非 mip-extensions 仓库的组件请在[组件平台](https://www.mipengine.org/platform/mip#/)提交，否则一律打回；